### PR TITLE
Add Ansible configuration for MySQL server / client

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,0 +1,58 @@
+# Server setup with Ansible
+Ansible is a free software platform for configuring and managing computers.
+It combines multi-node software deployment, ad hoc task execution, and configuration management.
+## Ansible setup
+On debian
+```
+sudo launchctl limit maxfiles 1024 2048
+sudo apt-get install software-properties-common
+sudo apt-add-repository ppa:ansible/ansible
+sudo apt-get update
+sudo apt-get install ansible sshpass
+```
+
+## Managed Node Requirements
+On the managed nodes, you need a way to communicate, normally ssh.
+By default Ansible uses sftp, if not available you can switch to scp in ansible.cfg.
+Also you need Python 2.4 or later, but if you are running less than Python 2.5 on the remotes, you will also need:
+```
+python-simplejson
+```
+
+## Setup of Node servers
+1. Register node servers in `/etc/ansible/hosts`
+2. Test communication with node servers
+```
+ansible all -m ping --user=XXXXXX --vault-password-file=.p --sudo --ask-sudo-pass
+```
+or (better) with private key authentification
+```
+ansible all -m ping --user=XXXXXX --private-key=p.key --sudo --ask-sudo-pass
+```
+
+3. Play a playbook
+```
+ansible-playbook mysql_server_setup.yml [+authentification options]
+```
+
+# Structure of the repository
+- defaults:
+default variables used by a role
+
+- files:
+files that need to be added to the machine being provisioned, without modification
+
+- handlers:
+handlers usually contain targets for notify directives
+
+- meta:
+The metadata of an Ansible role consists of attributes such as author, supported platforms, and dependencies.
+
+- tasks:
+Series of Ansible plays to install, configure, and run software.
+
+- templates:
+files that may be modified (Jinja2 template engine)
+
+- vars:
+variables with high priority

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -29,7 +29,6 @@ or (better) with private key authentification
 ```
 ansible all -m ping --user=XXXXXX --private-key=p.key --sudo --ask-sudo-pass
 ```
-
 3. Play a playbook
 ```
 ansible-playbook mysql_server_setup.yml [+authentification options]

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -4,7 +4,6 @@ It combines multi-node software deployment, ad hoc task execution, and configura
 ## Ansible setup
 On debian
 ```
-sudo launchctl limit maxfiles 1024 2048
 sudo apt-get install software-properties-common
 sudo apt-add-repository ppa:ansible/ansible
 sudo apt-get update

--- a/ansible/mysql_server_setup.yml
+++ b/ansible/mysql_server_setup.yml
@@ -1,0 +1,10 @@
+# Example script.
+# Setups MySQL server
+# Password is randomly generated
+# see roles/mysql_server_setup/defaults/main.yml for customization variables
+- hosts: local
+  roles:
+     - { role: mysql_server_setup
+        # ,mysql_root_password: 'secret'
+        # , ...
+       }

--- a/ansible/roles/mysql_server_setup/handlers/main.yml
+++ b/ansible/roles/mysql_server_setup/handlers/main.yml
@@ -1,0 +1,5 @@
+- name: Restart mysql
+  service: name=mysql state=restarted
+
+- name: Reload mysql
+  service: name=mysql state=reloaded

--- a/ansible/roles/mysql_server_setup/tasks/main.yml
+++ b/ansible/roles/mysql_server_setup/tasks/main.yml
@@ -1,0 +1,125 @@
+- name: Check if MySQL server is installed
+  stat:
+    path: '/usr/bin/mysqld_safe'
+  register: mysql_installed
+
+# We use debconf to remember the mysql root password before installing it
+- name: Set MySQL root password before installing
+  debconf: name='mysql-server' question='mysql-server/root_password' value='{{ mysql_root_password }}' vtype='password'
+  when: mysql_installed is defined and not mysql_installed.stat.exists
+
+- name: Re-enter MySQL root password before installing
+  debconf: name='mysql-server' question='mysql-server/root_password_again' value='{{ mysql_root_password }}' vtype='password'
+  when: mysql_installed is defined and not mysql_installed.stat.exists
+
+- name: Install MySQL-related packages
+  apt:
+    name: '{{ item }}'
+    state: 'latest'
+    install_recommends: False
+  register: mysql_install_status
+  with_items: [ 'python-mysqldb', 'mysql-server', 'automysqlbackup', 'ssl-cert' ]
+
+- name: Add MySQL system user to specified groups
+  user:
+    name: 'mysql'
+    groups: '{{ mysql_mysqld_append_groups | join(",") | default(omit) }}'
+    append: True
+    createhome: False
+  when: mysql_pki is defined and mysql_pki|bool
+  notify: [ 'Restart mysql' ]
+
+- name: Apply MySQL Server configuration
+  template:
+    src: 'etc/mysql/mysqld.cnf.j2'
+    dest: '/etc/mysql/conf.d/mysqld.cnf'
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+  notify: [ 'Restart mysql' ]
+
+- name: Apply MySQL Client configuration
+  template:
+    src: 'etc/mysql/client.cnf.j2'
+    dest: '/etc/mysql/conf.d/client.cnf'
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+  notify: [ 'Restart mysql' ]
+
+- name: Restart MySQL service on first install
+  service:
+    name: 'mysql'
+    state: 'restarted'
+  when: ((mysql_installed is defined and not mysql_installed.stat.exists) and
+         (mysql_install_status is defined and mysql_install_status.changed))
+
+
+# ---- Secure MySQL installation ----
+
+- name: Update mysql root password for all root accounts
+  mysql_user:
+    name: root
+    host: '{{ item }}'
+    password: "{{ mysql_root_password }}"
+    login_user: root
+    login_password: "{{ mysql_root_password }}"
+    check_implicit_admin: yes
+    priv: "*.*:ALL,GRANT"
+  with_items: [ '{{ ansible_hostname }}', '127.0.0.1', '::1', 'localhost' ]
+  when: mysql_installed is defined and not mysql_installed.stat.exists
+
+- name: Create /root/.my.cnf file with root password credentials
+  template:
+    src: 'root/my.cnf.j2'
+    dest: '/root/.my.cnf'
+    owner: 'root'
+    group: 'root'
+    mode: '0600'
+  when: mysql_installed is defined and not mysql_installed.stat.exists
+
+- name: Delete anonymous mysql user
+  mysql_user:
+    user: ""
+    host: '{{ item }}'
+    login_user: root
+    login_password: "{{ mysql_root_password }}"
+    state: 'absent'
+  with_items: [ '{{ ansible_hostname }}', 'localhost' ]
+
+- name: Remove test database
+  mysql_db:
+    db: 'test'
+    state: 'absent'
+    login_user: root
+    login_password: "{{ mysql_root_password }}"
+
+# ---- Manage MySQL databases and users ----
+
+- name: Manage MySQL databases
+  mysql_db:
+    name: '{{ item.name }}'
+    state: '{{ item.state | default("present") }}'
+    login_user: root
+    login_password: "{{ mysql_root_password }}"
+  with_items: mysql_databases
+  when: item.name is defined and item.name
+
+- name: Manage MySQL users
+  mysql_user:
+    name: '{{ item.name }}'
+    password: '{{ item.password | default(lookup("password", secret + "/credentials/" + ansible_fqdn + "/mysql/" + item.name + "/password chars=ascii_letters,digits,hexdigits length=" + mysql_password_length)) }}'
+    state: '{{ item.state | default("present") }}'
+    priv: '{{ item.priv | default(item.name + ".*:ALL") }}'
+    append_privs: '{{ item.append_privs | default("no") }}'
+    host: '{{ item.host | default("localhost") }}'
+    login_user: root
+    login_password: "{{ mysql_root_password }}"
+  with_items: mysql_users
+  when: (item.name is defined and item.name)
+
+- name: Restart MySQL service (again) after first configuration
+  service:
+    name: 'mysql'
+    state: 'restarted'
+  when: (mysql_installed is defined and not mysql_installed.stat.exists)

--- a/ansible/roles/mysql_server_setup/templates/etc/mysql/client.cnf.j2
+++ b/ansible/roles/mysql_server_setup/templates/etc/mysql/client.cnf.j2
@@ -1,0 +1,8 @@
+# This file is managed by Ansible, all changes will be lost
+
+[client]
+default-character-set		= utf8
+
+[mysql]
+prompt                          = {{ mysql_client_prompt }}
+

--- a/ansible/roles/mysql_server_setup/templates/etc/mysql/mysqld.cnf.j2
+++ b/ansible/roles/mysql_server_setup/templates/etc/mysql/mysqld.cnf.j2
@@ -1,0 +1,28 @@
+# This file is managed by Ansible, all changes will be lost
+
+[mysqld]
+bind-address		= {{ mysql_mysqld_bind_address }}
+port			= {{ mysql_mysqld_port }}
+max-connections		= {{ mysql_mysqld_max_connections }}
+
+character-set-server	= utf8
+collation-server	= utf8_general_ci
+init-connect		= 'SET NAMES utf8'
+
+{% if mysql_pki is defined and mysql_pki %}
+# Support for encrypted connections
+ssl
+ssl-ca			= {{ mysql_pki_path + "/" + mysql_pki_realm + "/" + mysql_pki_ca }}
+ssl-cert		= {{ mysql_pki_path + "/" + mysql_pki_realm + "/" + mysql_pki_crt }}
+ssl-key			= {{ mysql_pki_path + "/" + mysql_pki_realm + "/" + mysql_pki_key }}
+ssl-cipher		= {{ mysql_pki_cipher | default('DHE-RSA-AES256-SHA') }}
+
+{% endif %}
+
+{% if mysql_mysqld_options is defined and mysql_mysqld_options is not none %}
+{% for key, value in mysql_mysqld_options.iteritems() %}
+{{ key }}{% if value is not none %} = {{ value }}{% endif %}
+
+{% endfor %}
+
+{% endif %}


### PR DESCRIPTION
Tested on Debian.

This script:
1. Sets up MySQL with a random generated password
2. Imports custom MySQL server / client config
3. Creates a ".my.cnf" file readable only for root user with root password (no need to type the password on the "mysql" command)
4. May be used to create custom users / custom databases

Remaining todo list for MySQL config:
- Automatic backup system
- iptables rule ?
