### PR TITLE
Debug vagrant provisioning failure

### DIFF
--- a/vagrant_bootstrap.sh
+++ b/vagrant_bootstrap.sh
@@ -33,13 +33,18 @@ class contains_all_list(list):
     def __contains__(self, key):
         return True
 
-INTERNAL_IPS = contains_all_list()" > sigma/settings.py
+INTERNAL_IPS = contains_all_list()
+
+MIDDLEWARE = [
+    'debug_toolbar.middleware.DebugToolbarMiddleware',
+]" > sigma/settings.py
 
 echo "${LINE_BREAK_UP}"
 echo '# 2/6 Backend setup - pip requirements'
 echo "${LINE_BREAK}"
 
 sudo chown -R vagrant:vagrant /vagrant/backend
+pip3 install 'six>=1.10.0'
 pip3 install -r requirements/dev.txt
 pip3 install -r requirements/prod.txt
 

--- a/vagrant_bootstrap.sh
+++ b/vagrant_bootstrap.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x -e
+
 # pour le proxy à polytechnique, lignes à décommenter si vous y êtes
 
 # export HTTP_PROXY="http://129.104.247.2:8080"

--- a/vagrant_bootstrap.sh
+++ b/vagrant_bootstrap.sh
@@ -57,8 +57,8 @@ echo "${LINE_BREAK}"
 
 curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add -
 DISTRO="vivid"
-echo 'deb https://deb.nodesource.com/node_5.x ${DISTRO} main' > /etc/apt/sources.list.d/nodesource.list
-echo 'deb-src https://deb.nodesource.com/node_5.x ${DISTRO} main' >> /etc/apt/sources.list.d/nodesource.list
+echo "deb https://deb.nodesource.com/node_5.x ${DISTRO} main" > /etc/apt/sources.list.d/nodesource.list
+echo "deb-src https://deb.nodesource.com/node_5.x ${DISTRO} main" >> /etc/apt/sources.list.d/nodesource.list
 apt-get install -yqq nodejs npm
 
 cd /vagrant/frontend

--- a/vagrant_bootstrap.sh
+++ b/vagrant_bootstrap.sh
@@ -61,10 +61,11 @@ echo '# 4/6 Frontend setup - apt packages'
 echo "${LINE_BREAK}"
 
 curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add -
-DISTRO="vivid"
+DISTRO="trusty"
 echo "deb https://deb.nodesource.com/node_5.x ${DISTRO} main" > /etc/apt/sources.list.d/nodesource.list
 echo "deb-src https://deb.nodesource.com/node_5.x ${DISTRO} main" >> /etc/apt/sources.list.d/nodesource.list
-apt-get install -yqq nodejs npm
+apt-get update
+apt-get install -yqq nodejs
 
 cd /vagrant/frontend
 # Remove old modules from previous install / host machine


### PR DESCRIPTION
Hello,

As I would like to see what ProjetSigma look like, I am looking forward to build a virtual machine with it. Currently the provided Vagrant configuration file fails in several places and this Pull Request fixes some of them. With it, there is one last failure I do not understand, when running ``npm install --loglevel=info`` as user ``vagrant`` in ``/vagrant/frontend``:

```
[22:54:48] Requiring external module ts-node/register
TSError: ⨯ Unable to compile TypeScript
src/shared/services/api-service.ts (7,23): Cannot find module '../../config'. (2307)
src/shared/services/auth-service.ts (3,23): Cannot find module '../../config'. (2307)
    at getOutput (/vagrant/frontend/node_modules/ts-node/src/ts-node.ts:210:13)
    at Object.loader (/vagrant/frontend/node_modules/ts-node/src/ts-node.ts:225:23)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Module.require (module.js:367:17)
    at require (internal/module.js:20:19)
    at Liftoff.handleArguments (/vagrant/frontend/node_modules/gulp/bin/gulp.js:116:3)
    at Liftoff.<anonymous> (/vagrant/frontend/node_modules/liftoff/index.js:198:16)
    at module.exports (/vagrant/frontend/node_modules/flagged-respawn/index.js:17:3)
    at Liftoff.<anonymous> (/vagrant/frontend/node_modules/liftoff/index.js:190:9)

npm info lifecycle sigma@1.0.0~postinstall: Failed to exec postinstall script
npm WARN optional Skipping failed optional dependency /chokidar/fsevents:
npm WARN notsup Not compatible with your operating system or architecture: fsevents@1.0.17
npm ERR! Linux 3.13.0-107-generic
npm ERR! argv "/usr/bin/nodejs" "/usr/bin/npm" "install" "--loglevel=info"
npm ERR! node v5.12.0
npm ERR! npm  v3.8.6
npm ERR! code ELIFECYCLE
npm ERR! sigma@1.0.0 postinstall: `typings install && gulp check.versions && npm prune`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the sigma@1.0.0 postinstall script 'typings install && gulp check.versions && npm prune'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the sigma package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     typings install && gulp check.versions && npm prune
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs sigma
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls sigma
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /vagrant/frontend/npm-debug.log
```

I do not understand this error so any hint about what would have gone wrong would be appreciated :)
Cheers!